### PR TITLE
Run cloud test and cleanup

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -1,388 +1,54 @@
 package cmd
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strconv"
-	"sync"
-	"time"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
-	"go.k6.io/k6/errext"
-	"go.k6.io/k6/errext/exitcodes"
-	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
-	"go.k6.io/k6/ui/pb"
 )
 
-// cmdCloud handles the `k6 cloud` sub-command
-type cmdCloud struct {
-	gs *state.GlobalState
-
-	showCloudLogs bool
-	exitOnRunning bool
-	uploadOnly    bool
-	orgId         string
-	projId        string
-}
-
-func (c *cmdCloud) preRun(cmd *cobra.Command, _ []string) error {
-	// TODO: refactor (https://github.com/loadimpact/k6/issues/883)
-	//
-	// We deliberately parse the env variables, to validate for wrong
-	// values, even if we don't subsequently use them (if the respective
-	// CLI flag was specified, since it has a higher priority).
-	if showCloudLogsEnv, ok := c.gs.Env["K6_SHOW_CLOUD_LOGS"]; ok {
-		showCloudLogsValue, err := strconv.ParseBool(showCloudLogsEnv)
-		if err != nil {
-			return fmt.Errorf("parsing K6_SHOW_CLOUD_LOGS returned an error: %w", err)
-		}
-		if !cmd.Flags().Changed("show-logs") {
-			c.showCloudLogs = showCloudLogsValue
-		}
-	}
-
-	if exitOnRunningEnv, ok := c.gs.Env["K6_EXIT_ON_RUNNING"]; ok {
-		exitOnRunningValue, err := strconv.ParseBool(exitOnRunningEnv)
-		if err != nil {
-			return fmt.Errorf("parsing K6_EXIT_ON_RUNNING returned an error: %w", err)
-		}
-		if !cmd.Flags().Changed("exit-on-running") {
-			c.exitOnRunning = exitOnRunningValue
-		}
-	}
-	if uploadOnlyEnv, ok := c.gs.Env["K6_CLOUD_UPLOAD_ONLY"]; ok {
-		uploadOnlyValue, err := strconv.ParseBool(uploadOnlyEnv)
-		if err != nil {
-			return fmt.Errorf("parsing K6_CLOUD_UPLOAD_ONLY returned an error: %w", err)
-		}
-		if !cmd.Flags().Changed("upload-only") {
-			c.uploadOnly = uploadOnlyValue
-		}
-	}
-
-	return nil
-}
-
-// TODO: split apart some more
-//
-//nolint:funlen,gocognit,cyclop
-func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
-	printBanner(c.gs)
-
-	progressBar := pb.New(
-		pb.WithConstLeft("Init"),
-		pb.WithConstProgress(0, "Loading test script..."),
-	)
-	printBar(c.gs, progressBar)
-
-	test, err := loadAndConfigureTest(c.gs, cmd, args, getPartialConfig)
+func getCloudClient(gs *state.GlobalState) (*cloudapi.K6CloudClient, error) {
+	currentDiskConf, err := readDiskConfig(gs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// It's important to NOT set the derived options back to the runner
-	// here, only the consolidated ones. Otherwise, if the script used
-	// an execution shortcut option (e.g. `iterations` or `duration`),
-	// we will have multiple conflicting execution options since the
-	// derivation will set `scenarios` as well.
-	testRunState, err := test.buildTestRunState(test.consolidatedConfig.Options)
+	cloudConfig, err := cloudapi.GetConsolidatedConfig(currentDiskConf.Collectors["cloud"], gs.Env, "", nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: validate for usage of execution segment
-	// TODO: validate for externally controlled executor (i.e. executors that aren't distributable)
-	// TODO: move those validations to a separate function and reuse validateConfig()?
-
-	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Building the archive..."))
-	arc := testRunState.Runner.MakeArchive()
-
-	// TODO: Fix this
-	// We reuse cloud.Config for parsing options.ext.loadimpact, but this probably shouldn't be
-	// done, as the idea of options.ext is that they are extensible without touching k6. But in
-	// order for this to happen, we shouldn't actually marshall cloud.Config on top of it, because
-	// it will be missing some fields that aren't actually mentioned in the struct.
-	// So in order for use to copy the fields that we need for loadimpact's api we unmarshal in
-	// map[string]interface{} and copy what we need if it isn't set already
-	var tmpCloudConfig map[string]interface{}
-	if val, ok := arc.Options.External["loadimpact"]; ok {
-		dec := json.NewDecoder(bytes.NewReader(val))
-		dec.UseNumber() // otherwise float64 are used
-		if err = dec.Decode(&tmpCloudConfig); err != nil {
-			return err
-		}
-	}
-
-	// Cloud config
-	cloudConfig, err := cloudapi.GetConsolidatedConfig(
-		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.External)
-	if err != nil {
-		return err
-	}
 	if !cloudConfig.Token.Valid {
-		return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck
-	}
-	if tmpCloudConfig == nil {
-		tmpCloudConfig = make(map[string]interface{}, 3)
+		return nil, errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck
 	}
 
-	if cloudConfig.Token.Valid {
-		tmpCloudConfig["token"] = cloudConfig.Token
-	}
-	if cloudConfig.Name.Valid {
-		tmpCloudConfig["name"] = cloudConfig.Name
-	}
-	if cloudConfig.ProjectID.Valid {
-		tmpCloudConfig["projectID"] = cloudConfig.ProjectID
-	}
-
-	if arc.Options.External == nil {
-		arc.Options.External = make(map[string]json.RawMessage)
-	}
-	arc.Options.External["loadimpact"], err = json.Marshal(tmpCloudConfig)
-	if err != nil {
-		return err
-	}
-
-	name := cloudConfig.Name.String
-	if !cloudConfig.Name.Valid || cloudConfig.Name.String == "" {
-		name = filepath.Base(test.sourceRootPath)
-	}
-
-	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
-	defer globalCancel()
-
-	logger := c.gs.Logger
-
-	// Start cloud test run
-	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Validating script options"))
-	client := cloudapi.NewClient(
-		logger, cloudConfig.Token.String, cloudConfig.Host.String, consts.Version, cloudConfig.Timeout.TimeDuration())
-	if err = client.ValidateOptions(arc.Options); err != nil {
-		return err
-	}
-
-	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
-
-	var cloudTestRun *cloudapi.CreateTestRunResponse
-	if c.uploadOnly {
-		cloudTestRun, err = client.UploadTestOnly(name, cloudConfig.ProjectID.Int64, arc)
-	} else {
-		cloudTestRun, err = client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	refID := cloudTestRun.ReferenceID
-	if cloudTestRun.ConfigOverride != nil {
-		cloudConfig = cloudConfig.Apply(*cloudTestRun.ConfigOverride)
-	}
-
-	// Trap Interrupts, SIGINTs and SIGTERMs.
-	gracefulStop := func(sig os.Signal) {
-		logger.WithField("sig", sig).Print("Stopping cloud test run in response to signal...")
-		// Do this in a separate goroutine so that if it blocks, the
-		// second signal can still abort the process execution.
-		go func() {
-			stopErr := client.StopCloudTestRun(refID)
-			if stopErr != nil {
-				logger.WithError(stopErr).Error("Stop cloud test error")
-			} else {
-				logger.Info("Successfully sent signal to stop the cloud test, now waiting for it to actually stop...")
-			}
-			globalCancel()
-		}()
-	}
-	onHardStop := func(sig os.Signal) {
-		logger.WithField("sig", sig).Error("Aborting k6 in response to signal, we won't wait for the test to end.")
-	}
-	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
-	defer stopSignalHandling()
-
-	et, err := lib.NewExecutionTuple(test.derivedConfig.ExecutionSegment, test.derivedConfig.ExecutionSegmentSequence)
-	if err != nil {
-		return err
-	}
-	testURL := cloudapi.URLForResults(refID, cloudConfig)
-	executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
-	printExecutionDescription(
-		c.gs, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
-	)
-
-	modifyAndPrintBar(
-		c.gs, progressBar,
-		pb.WithConstLeft("Run "), pb.WithConstProgress(0, "Initializing the cloud test"),
-	)
-
-	progressCtx, progressCancel := context.WithCancel(globalCtx)
-	progressBarWG := &sync.WaitGroup{}
-	progressBarWG.Add(1)
-	defer progressBarWG.Wait()
-	defer progressCancel()
-	go func() {
-		showProgress(progressCtx, c.gs, []*pb.ProgressBar{progressBar}, logger)
-		progressBarWG.Done()
-	}()
-
-	var (
-		startTime   time.Time
-		maxDuration time.Duration
-	)
-	maxDuration, _ = lib.GetEndOffset(executionPlan)
-
-	testProgressLock := &sync.Mutex{}
-	var testProgress *cloudapi.TestProgressResponse
-	progressBar.Modify(
-		pb.WithProgress(func() (float64, []string) {
-			testProgressLock.Lock()
-			defer testProgressLock.Unlock()
-
-			if testProgress == nil {
-				return 0, []string{"Waiting..."}
-			}
-
-			statusText := testProgress.RunStatusText
-
-			if testProgress.RunStatus == cloudapi.RunStatusFinished {
-				testProgress.Progress = 1
-			} else if testProgress.RunStatus == cloudapi.RunStatusRunning {
-				if startTime.IsZero() {
-					startTime = time.Now()
-				}
-				spent := time.Since(startTime)
-				if spent > maxDuration {
-					statusText = maxDuration.String()
-				} else {
-					statusText = fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, maxDuration), maxDuration)
-				}
-			}
-
-			return testProgress.Progress, []string{statusText}
-		}),
-	)
-
-	ticker := time.NewTicker(time.Millisecond * 2000)
-	if c.showCloudLogs {
-		go func() {
-			logger.Debug("Connecting to cloud logs server...")
-			if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
-				logger.WithError(err).Error("error while tailing cloud logs")
-			}
-		}()
-	}
-
-	for range ticker.C {
-		newTestProgress, progressErr := client.GetTestProgress(refID)
-		if progressErr != nil {
-			logger.WithError(progressErr).Error("Test progress error")
-			continue
-		}
-
-		testProgressLock.Lock()
-		testProgress = newTestProgress
-		testProgressLock.Unlock()
-
-		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
-			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
-			globalCancel()
-			break
-		}
-	}
-
-	if testProgress == nil {
-		//nolint:stylecheck,golint
-		return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
-	}
-
-	if !c.gs.Flags.Quiet {
-		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
-		printToStdout(c.gs, fmt.Sprintf(
-			"     test status: %s\n", valueColor.Sprint(testProgress.RunStatusText),
-		))
-	} else {
-		logger.WithField("run_status", testProgress.RunStatusText).Debug("Test finished")
-	}
-
-	if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
-		// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
-		//nolint:stylecheck,golint
-		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
-	}
-
-	return nil
-}
-
-func (c *cmdCloud) flagSet() *pflag.FlagSet {
-	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	flags.SortFlags = false
-	flags.AddFlagSet(optionFlagSet())
-	flags.AddFlagSet(runtimeOptionFlagSet(false))
-
-	// TODO: Figure out a better way to handle the CLI flags
-	flags.BoolVar(&c.exitOnRunning, "exit-on-running", c.exitOnRunning,
-		"exits when test reaches the running status")
-	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
-		"enable showing of logs when a test is executed in the cloud")
-	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
-		"only upload the test to the cloud without actually starting a test run")
-
-	return flags
+	apiClient := cloudapi.NewK6CloudClient(
+		gs.Logger, cloudConfig.Token.String, cloudConfig.APIHost.String, consts.Version, cloudConfig.Timeout.TimeDuration())
+	return apiClient, nil
 }
 
 func getCmdCloud(gs *state.GlobalState) *cobra.Command {
-	c := &cmdCloud{
-		gs:            gs,
-		showCloudLogs: true,
-		exitOnRunning: false,
-		uploadOnly:    false,
-	}
-
-	exampleText := getExampleText(gs, `
-  {{.}} cloud script.js`[1:])
-
-	cloudCmd := &cobra.Command{
-		Use:   "cloud",
-		Short: "Run a test on the cloud",
-		Long: `Run a test on the cloud.
-
-This will execute the test on the k6 cloud service. Use "k6 login cloud" to authenticate.`,
-		Example: exampleText,
-		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
-		PreRunE: c.preRun,
-		RunE:    c.run,
-	}
-	cloudCmd.Flags().SortFlags = false
-	cloudCmd.Flags().AddFlagSet(c.flagSet())
-	cloudCmd.PersistentFlags().StringVar(&c.orgId, "org-id", "", "Organization id")
-	cloudCmd.PersistentFlags().StringVar(&c.projId, "proj-id", "", "Project id")
-	cloudConfig, err := cloudapi.GetConsolidatedConfig(nil, c.gs.Env, "", nil)
+	client, err := getCloudClient(gs)
 	if err != nil {
-		fmt.Println("%s", err)
+		gs.Logger.Error(err)
 		os.Exit(1)
 	}
-	logger := c.gs.Logger
-	client := cloudapi.NewK6CloudClient(logger, cloudConfig.Token.String, cloudConfig.APIHost.String, consts.Version, cloudConfig.Timeout.TimeDuration())
+	cmd := &cobra.Command{Use: "cloud"}
 
-	cloudCmd.AddCommand(getCloudProjectCmd(client, c))
-	cloudCmd.AddCommand(getCloudLoadZoneCmd(client, c))
-	cloudCmd.AddCommand(getCloudOrganizationCmd(client, c))
-	cloudCmd.AddCommand(getCloudTestCmd(client, c))
-	cloudCmd.AddCommand(getCloudTestRunCmd(client, c))
+	cmd.AddCommand(
+		getCloudProjectCmd(client),
+		getCloudLoadZoneCmd(client),
+		getCloudOrganizationCmd(client),
+		getCloudTestCmd(gs, client),
+		getCloudTestRunCmd(client),
+	)
 
-	return cloudCmd
+	return cmd
 }
 
 // CloudOutput will eventually allow us to putput JSON and other formats. For now it just helps standarise things.

--- a/cmd/cloud_loadzone.go
+++ b/cmd/cloud_loadzone.go
@@ -5,14 +5,15 @@ import (
 	"go.k6.io/k6/cloudapi"
 )
 
-func getCloudLoadZoneCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command {
+func getCloudLoadZoneCmd(client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud loadzone
 	loadzoneSub := &cobra.Command{Use: "loadzone"}
 	// k6 cloud loadzone list
-	loadzoneSub.AddCommand(&cobra.Command{
+	var orgId string
+	listLoadZones := &cobra.Command{
 		Use: "list",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loadzones, err := client.ListCloudLoadZones(c.orgId)
+			loadzones, err := client.ListCloudLoadZones(orgId)
 			if err != nil {
 				return err
 			}
@@ -28,6 +29,10 @@ func getCloudLoadZoneCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Com
 				})
 			}
 			return nil
-		}})
+		}}
+	listLoadZones.Flags().StringVar(&orgId, "org-id", "", "Organization id")
+
+	loadzoneSub.AddCommand(listLoadZones)
+
 	return loadzoneSub
 }

--- a/cmd/cloud_organization.go
+++ b/cmd/cloud_organization.go
@@ -5,11 +5,11 @@ import (
 	"go.k6.io/k6/cloudapi"
 )
 
-func getCloudOrganizationCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command {
+func getCloudOrganizationCmd(client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud organization
 	organizationSub := &cobra.Command{Use: "organization"}
 	// k6 cloud organization list
-	organizationSub.AddCommand(&cobra.Command{
+	listOrganizations := &cobra.Command{
 		Use: "list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgs, err := client.ListCloudOrganizations()
@@ -26,6 +26,9 @@ func getCloudOrganizationCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra
 				})
 			}
 			return nil
-		}})
+		}}
+
+	organizationSub.AddCommand(listOrganizations)
+
 	return organizationSub
 }

--- a/cmd/cloud_project.go
+++ b/cmd/cloud_project.go
@@ -5,14 +5,15 @@ import (
 	"go.k6.io/k6/cloudapi"
 )
 
-func getCloudProjectCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command {
+func getCloudProjectCmd(client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud project
 	projectSub := &cobra.Command{Use: "project"}
 	// k6 cloud project list
-	projectSub.AddCommand(&cobra.Command{
+	var orgId string
+	listProjects := &cobra.Command{
 		Use: "list",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			projects, err := client.ListCloudProjects(c.orgId)
+			projects, err := client.ListCloudProjects(orgId)
 			if err != nil {
 				return err
 			}
@@ -26,6 +27,10 @@ func getCloudProjectCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Comm
 				})
 			}
 			return nil
-		}})
+		}}
+	listProjects.Flags().StringVar(&orgId, "org-id", "", "Organization id")
+
+	projectSub.AddCommand(listProjects)
+
 	return projectSub
 }

--- a/cmd/cloud_test_.go
+++ b/cmd/cloud_test_.go
@@ -1,20 +1,584 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/ui/pb"
 )
 
 // NOTE: This file ends with an underscore so it isn't a test file.
 
-func getCloudTestCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command {
+const (
+	testIDNotSet = -1
+)
+
+// cmdCloudRunTest handles the `k6 cloud` sub-command
+type cmdCloudRunTest struct {
+	gs *state.GlobalState
+
+	testID        int64
+	showCloudLogs bool
+	exitOnRunning bool
+	uploadOnly    bool
+}
+
+func (c *cmdCloudRunTest) preRun(cmd *cobra.Command, _ []string) error {
+	// TODO: refactor (https://github.com/loadimpact/k6/issues/883)
+	//
+	// We deliberately parse the env variables, to validate for wrong
+	// values, even if we don't subsequently use them (if the respective
+	// CLI flag was specified, since it has a higher priority).
+	if showCloudLogsEnv, ok := c.gs.Env["K6_SHOW_CLOUD_LOGS"]; ok {
+		showCloudLogsValue, err := strconv.ParseBool(showCloudLogsEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_SHOW_CLOUD_LOGS returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("show-logs") {
+			c.showCloudLogs = showCloudLogsValue
+		}
+	}
+
+	if exitOnRunningEnv, ok := c.gs.Env["K6_EXIT_ON_RUNNING"]; ok {
+		exitOnRunningValue, err := strconv.ParseBool(exitOnRunningEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_EXIT_ON_RUNNING returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("exit-on-running") {
+			c.exitOnRunning = exitOnRunningValue
+		}
+	}
+	if uploadOnlyEnv, ok := c.gs.Env["K6_CLOUD_UPLOAD_ONLY"]; ok {
+		uploadOnlyValue, err := strconv.ParseBool(uploadOnlyEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_CLOUD_UPLOAD_ONLY returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("upload-only") {
+			c.uploadOnly = uploadOnlyValue
+		}
+	}
+
+	return nil
+}
+
+// TODO: split apart some more
+//
+//nolint:funlen,gocognit,cyclop
+func (c *cmdCloudRunTest) runWithScript(cmd *cobra.Command, args []string) error {
+	printBanner(c.gs)
+
+	progressBar := pb.New(
+		pb.WithConstLeft("Init"),
+		pb.WithConstProgress(0, "Loading test script..."),
+	)
+	printBar(c.gs, progressBar)
+
+	test, err := loadAndConfigureTest(c.gs, cmd, args, getPartialConfig)
+	if err != nil {
+		return err
+	}
+
+	// It's important to NOT set the derived options back to the runner
+	// here, only the consolidated ones. Otherwise, if the script used
+	// an execution shortcut option (e.g. `iterations` or `duration`),
+	// we will have multiple conflicting execution options since the
+	// derivation will set `scenarios` as well.
+	testRunState, err := test.buildTestRunState(test.consolidatedConfig.Options)
+	if err != nil {
+		return err
+	}
+
+	// TODO: validate for usage of execution segment
+	// TODO: validate for externally controlled executor (i.e. executors that aren't distributable)
+	// TODO: move those validations to a separate function and reuse validateConfig()?
+
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Building the archive..."))
+	arc := testRunState.Runner.MakeArchive()
+
+	// TODO: Fix this
+	// We reuse cloud.Config for parsing options.ext.loadimpact, but this probably shouldn't be
+	// done, as the idea of options.ext is that they are extensible without touching k6. But in
+	// order for this to happen, we shouldn't actually marshall cloud.Config on top of it, because
+	// it will be missing some fields that aren't actually mentioned in the struct.
+	// So in order for use to copy the fields that we need for loadimpact's api we unmarshal in
+	// map[string]interface{} and copy what we need if it isn't set already
+	var tmpCloudConfig map[string]interface{}
+	if val, ok := arc.Options.External["loadimpact"]; ok {
+		dec := json.NewDecoder(bytes.NewReader(val))
+		dec.UseNumber() // otherwise float64 are used
+		if err = dec.Decode(&tmpCloudConfig); err != nil {
+			return err
+		}
+	}
+
+	// Cloud config
+	cloudConfig, err := cloudapi.GetConsolidatedConfig(
+		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.External)
+	if err != nil {
+		return err
+	}
+	if !cloudConfig.Token.Valid {
+		return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck
+	}
+	if tmpCloudConfig == nil {
+		tmpCloudConfig = make(map[string]interface{}, 3)
+	}
+
+	if cloudConfig.Token.Valid {
+		tmpCloudConfig["token"] = cloudConfig.Token
+	}
+	if cloudConfig.Name.Valid {
+		tmpCloudConfig["name"] = cloudConfig.Name
+	}
+	if cloudConfig.ProjectID.Valid {
+		tmpCloudConfig["projectID"] = cloudConfig.ProjectID
+	}
+
+	if arc.Options.External == nil {
+		arc.Options.External = make(map[string]json.RawMessage)
+	}
+	arc.Options.External["loadimpact"], err = json.Marshal(tmpCloudConfig)
+	if err != nil {
+		return err
+	}
+
+	name := cloudConfig.Name.String
+	if !cloudConfig.Name.Valid || cloudConfig.Name.String == "" {
+		name = filepath.Base(test.sourceRootPath)
+	}
+
+	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
+	defer globalCancel()
+
+	logger := c.gs.Logger
+
+	// Start cloud test run
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Validating script options"))
+	client := cloudapi.NewClient(
+		logger, cloudConfig.Token.String, cloudConfig.Host.String, consts.Version, cloudConfig.Timeout.TimeDuration())
+	if err = client.ValidateOptions(arc.Options); err != nil {
+		return err
+	}
+
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
+
+	var cloudTestRun *cloudapi.CreateTestRunResponse
+	if c.uploadOnly {
+		cloudTestRun, err = client.UploadTestOnly(name, cloudConfig.ProjectID.Int64, arc)
+	} else {
+		cloudTestRun, err = client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	refID := cloudTestRun.ReferenceID
+	if cloudTestRun.ConfigOverride != nil {
+		cloudConfig = cloudConfig.Apply(*cloudTestRun.ConfigOverride)
+	}
+
+	// Trap Interrupts, SIGINTs and SIGTERMs.
+	gracefulStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Print("Stopping cloud test run in response to signal...")
+		// Do this in a separate goroutine so that if it blocks, the
+		// second signal can still abort the process execution.
+		go func() {
+			stopErr := client.StopCloudTestRun(refID)
+			if stopErr != nil {
+				logger.WithError(stopErr).Error("Stop cloud test error")
+			} else {
+				logger.Info("Successfully sent signal to stop the cloud test, now waiting for it to actually stop...")
+			}
+			globalCancel()
+		}()
+	}
+	onHardStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Error("Aborting k6 in response to signal, we won't wait for the test to end.")
+	}
+	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
+	defer stopSignalHandling()
+
+	et, err := lib.NewExecutionTuple(test.derivedConfig.ExecutionSegment, test.derivedConfig.ExecutionSegmentSequence)
+	if err != nil {
+		return err
+	}
+	testURL := cloudapi.URLForResults(refID, cloudConfig)
+	executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
+	printExecutionDescription(
+		c.gs, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
+	)
+
+	modifyAndPrintBar(
+		c.gs, progressBar,
+		pb.WithConstLeft("Run "), pb.WithConstProgress(0, "Initializing the cloud test"),
+	)
+
+	progressCtx, progressCancel := context.WithCancel(globalCtx)
+	progressBarWG := &sync.WaitGroup{}
+	progressBarWG.Add(1)
+	defer progressBarWG.Wait()
+	defer progressCancel()
+	go func() {
+		showProgress(progressCtx, c.gs, []*pb.ProgressBar{progressBar}, logger)
+		progressBarWG.Done()
+	}()
+
+	var (
+		startTime   time.Time
+		maxDuration time.Duration
+	)
+	maxDuration, _ = lib.GetEndOffset(executionPlan)
+
+	testProgressLock := &sync.Mutex{}
+	var testProgress *cloudapi.TestProgressResponse
+	progressBar.Modify(
+		pb.WithProgress(func() (float64, []string) {
+			testProgressLock.Lock()
+			defer testProgressLock.Unlock()
+
+			if testProgress == nil {
+				return 0, []string{"Waiting..."}
+			}
+
+			statusText := testProgress.RunStatusText
+
+			if testProgress.RunStatus == cloudapi.RunStatusFinished {
+				testProgress.Progress = 1
+			} else if testProgress.RunStatus == cloudapi.RunStatusRunning {
+				if startTime.IsZero() {
+					startTime = time.Now()
+				}
+				spent := time.Since(startTime)
+				if spent > maxDuration {
+					statusText = maxDuration.String()
+				} else {
+					statusText = fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, maxDuration), maxDuration)
+				}
+			}
+
+			return testProgress.Progress, []string{statusText}
+		}),
+	)
+
+	ticker := time.NewTicker(time.Millisecond * 2000)
+	if c.showCloudLogs {
+		go func() {
+			logger.Debug("Connecting to cloud logs server...")
+			if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
+				logger.WithError(err).Error("error while tailing cloud logs")
+			}
+		}()
+	}
+
+	for range ticker.C {
+		newTestProgress, progressErr := client.GetTestProgress(refID)
+		if progressErr != nil {
+			logger.WithError(progressErr).Error("Test progress error")
+			continue
+		}
+
+		testProgressLock.Lock()
+		testProgress = newTestProgress
+		testProgressLock.Unlock()
+
+		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
+			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
+			globalCancel()
+			break
+		}
+	}
+
+	if testProgress == nil {
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
+	}
+
+	if !c.gs.Flags.Quiet {
+		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
+		printToStdout(c.gs, fmt.Sprintf(
+			"     test status: %s\n", valueColor.Sprint(testProgress.RunStatusText),
+		))
+	} else {
+		logger.WithField("run_status", testProgress.RunStatusText).Debug("Test finished")
+	}
+
+	if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
+		// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
+	}
+
+	return nil
+}
+
+func (c *cmdCloudRunTest) runById(cmd *cobra.Command, args []string) error {
+	printBanner(c.gs)
+
+	progressBar := pb.New(
+		pb.WithConstLeft("Init"),
+		pb.WithConstProgress(0, "Starting the test..."),
+	)
+	printBar(c.gs, progressBar)
+
+	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
+	defer globalCancel()
+
+	logger := c.gs.Logger
+
+	apiClient, err := getCloudClient(c.gs)
+	if err != nil {
+		return err
+	}
+
+	currentDiskConf, err := readDiskConfig(c.gs)
+	if err != nil {
+		return err
+	}
+
+	cloudConfig, err := cloudapi.GetConsolidatedConfig(currentDiskConf.Collectors["cloud"], c.gs.Env, "", nil)
+	if err != nil {
+		return err
+	}
+	client := cloudapi.NewClient(
+		logger, cloudConfig.Token.String, cloudConfig.Host.String, consts.Version, cloudConfig.Timeout.TimeDuration())
+
+	var cloudTestRun *cloudapi.CloudTestRun
+	cloudTestRun, err = apiClient.StartCloudTest(c.testID)
+	if err != nil {
+		return err
+	}
+
+	refID := strconv.FormatInt(cloudTestRun.ID, 10)
+
+	// Trap Interrupts, SIGINTs and SIGTERMs.
+	gracefulStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Print("Stopping cloud test run in response to signal...")
+		// Do this in a separate goroutine so that if it blocks, the
+		// second signal can still abort the process execution.
+		go func() {
+			stopErr := client.StopCloudTestRun(refID)
+			if stopErr != nil {
+				logger.WithError(stopErr).Error("Stop cloud test error")
+			} else {
+				logger.Info("Successfully sent signal to stop the cloud test, now waiting for it to actually stop...")
+			}
+			globalCancel()
+		}()
+	}
+	onHardStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Error("Aborting k6 in response to signal, we won't wait for the test to end.")
+	}
+	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
+	defer stopSignalHandling()
+
+	cloudConfig.TestRunDetails = cloudTestRun.RuntimeConfig.TestRunDetails
+	testURL := cloudapi.URLForResults(refID, cloudConfig)
+	printExecutionDescriptionBasic(c.gs, testURL)
+
+	modifyAndPrintBar(
+		c.gs, progressBar,
+		pb.WithConstLeft("Run "), pb.WithConstProgress(0, "Initializing the cloud test"),
+	)
+
+	progressCtx, progressCancel := context.WithCancel(globalCtx)
+	progressBarWG := &sync.WaitGroup{}
+	progressBarWG.Add(1)
+	defer progressBarWG.Wait()
+	defer progressCancel()
+	go func() {
+		showProgress(progressCtx, c.gs, []*pb.ProgressBar{progressBar}, logger)
+		progressBarWG.Done()
+	}()
+
+	var (
+		startTime   time.Time
+		maxDuration time.Duration
+	)
+
+	testProgressLock := &sync.Mutex{}
+	var testProgress *cloudapi.TestProgressResponse
+	progressBar.Modify(
+		pb.WithProgress(func() (float64, []string) {
+			testProgressLock.Lock()
+			defer testProgressLock.Unlock()
+
+			if testProgress == nil {
+				return 0, []string{"Waiting..."}
+			}
+
+			statusText := testProgress.RunStatusText
+
+			if testProgress.RunStatus == cloudapi.RunStatusRunning {
+				if startTime.IsZero() {
+					startTime = time.Now()
+				}
+				spent := time.Since(startTime)
+				if spent > maxDuration {
+					statusText = maxDuration.String()
+				} else {
+					statusText = fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, maxDuration), maxDuration)
+				}
+			} else if testProgress.RunStatus == cloudapi.RunStatusFinished {
+				testProgress.Progress = 1
+			}
+
+			return testProgress.Progress, []string{statusText}
+		}),
+	)
+
+	ticker := time.NewTicker(time.Millisecond * 2000)
+	if c.showCloudLogs {
+		go func() {
+			logger.Debug("Connecting to cloud logs server...")
+			if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
+				logger.WithError(err).Error("error while tailing cloud logs")
+			}
+		}()
+	}
+
+	for range ticker.C {
+		newTestProgress, progressErr := client.GetTestProgress(refID)
+		if progressErr != nil {
+			logger.WithError(progressErr).Error("Test progress error")
+			continue
+		}
+		if testProgress != nil &&
+			testProgress.RunStatus != newTestProgress.RunStatus &&
+			newTestProgress.RunStatus == cloudapi.RunStatusRunning {
+
+			var cloudTestRun *cloudapi.CloudTestRun
+			cloudTestRun, err = apiClient.GetCloudTestRun(refID)
+			maxDuration = time.Duration(cloudTestRun.Duration * 1e9)
+		}
+
+		testProgressLock.Lock()
+		testProgress = newTestProgress
+		testProgressLock.Unlock()
+
+		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
+			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
+			globalCancel()
+			break
+		}
+	}
+
+	if testProgress == nil {
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
+	}
+
+	if !c.gs.Flags.Quiet {
+		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
+		printToStdout(c.gs, fmt.Sprintf(
+			"     test status: %s\n", valueColor.Sprint(testProgress.RunStatusText),
+		))
+	} else {
+		logger.WithField("run_status", testProgress.RunStatusText).Debug("Test finished")
+	}
+
+	if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
+		// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
+	}
+
+	return nil
+}
+
+func (c *cmdCloudRunTest) run(cmd *cobra.Command, args []string) error {
+	if c.testID == testIDNotSet {
+		return c.runWithScript(cmd, args)
+	} else {
+		return c.runById(cmd, args)
+	}
+}
+
+func (c *cmdCloudRunTest) flagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.SortFlags = false
+	flags.AddFlagSet(optionFlagSet())
+	flags.AddFlagSet(runtimeOptionFlagSet(false))
+
+	// TODO: Figure out a better way to handle the CLI flags
+	flags.BoolVar(&c.exitOnRunning, "exit-on-running", c.exitOnRunning,
+		"exits when test reaches the running status")
+	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
+		"enable showing of logs when a test is executed in the cloud")
+	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
+		"only upload the test to the cloud without actually starting a test run")
+	flags.Int64Var(&c.testID, "test-id", testIDNotSet, "start existing test using provided id")
+	return flags
+}
+
+func getCloudCmdRunTest(gs *state.GlobalState) *cobra.Command {
+	c := &cmdCloudRunTest{
+		gs:            gs,
+		testID:        testIDNotSet,
+		showCloudLogs: true,
+		exitOnRunning: false,
+		uploadOnly:    false,
+	}
+
+	exampleText := getExampleText(gs, `
+  {{.}} cloud test run script.js`[1:])
+
+	cloudCmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run a test on the cloud",
+		Long: `Run a test on the cloud.
+
+This will execute the test on the k6 cloud service. Use "k6 login cloud" to authenticate.`,
+		Example: exampleText,
+		Args: func(cmd *cobra.Command, args []string) error {
+			testID, err := cmd.Flags().GetInt64("test-id")
+			if err != nil {
+				return err
+			}
+			if testID == testIDNotSet && len(args) != 1 {
+				return fmt.Errorf("accepts %d arg(s), received %d: %s", 1, len(args), "arg should either be \"-\", if reading script from stdin, or a path to a script file")
+			}
+			return nil
+		},
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+	cloudCmd.Flags().SortFlags = false
+	cloudCmd.Flags().AddFlagSet(c.flagSet())
+	return cloudCmd
+}
+
+func getCloudTestCmd(gs *state.GlobalState, client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud test
-	testsSub := &cobra.Command{Use: "test"}
-	// k6 cloud test list
-	testsSub.AddCommand(&cobra.Command{
+	testsSub := &cobra.Command{
+		Use:     "test",
+		Aliases: []string{"tests"},
+	}
+
+	var projId string
+	// k6 cloud test list\
+	listTests := &cobra.Command{
 		Use: "list",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tests, err := client.ListCloudTests(c.projId)
+			tests, err := client.ListCloudTests(projId)
 			if err != nil {
 				return err
 			}
@@ -28,6 +592,10 @@ func getCloudTestCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command
 				})
 			}
 			return nil
-		}})
+		}}
+	listTests.Flags().StringVar(&projId, "proj-id", "", "Project id")
+
+	testsSub.AddCommand(listTests, getCloudCmdRunTest(gs))
+
 	return testsSub
 }

--- a/cmd/cloud_test_run.go
+++ b/cmd/cloud_test_run.go
@@ -5,7 +5,7 @@ import (
 	"go.k6.io/k6/cloudapi"
 )
 
-func getCloudTestRunCmd(client *cloudapi.K6CloudClient, c *cmdCloud) *cobra.Command {
+func getCloudTestRunCmd(client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud testrun
 	testrunsSub := &cobra.Command{Use: "testrun"}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	stdlog "log"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -68,6 +69,14 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 
 	for _, sc := range subCommands {
 		rootCmd.AddCommand(sc(gs))
+	}
+
+	// hack to keep backwards compatibility with "k6 cloud" command to run a test from script
+	subCmd, _, err := rootCmd.Find(gs.CmdArgs[1:])
+	if err == nil && subCmd != nil && subCmd.Name() == "cloud" {
+		index := slices.Index(gs.CmdArgs, "cloud")
+		args := slices.Insert(gs.CmdArgs, index+1, "test", "run")[1:]
+		rootCmd.SetArgs(args)
 	}
 
 	c.cmd = rootCmd

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -93,6 +93,22 @@ func modifyAndPrintBar(gs *state.GlobalState, bar *pb.ProgressBar, options ...pb
 	printBar(gs, bar)
 }
 
+func printExecutionDescriptionBasic(gs *state.GlobalState, testURL string) {
+	noColor := gs.Flags.NoColor || !gs.Stdout.IsTTY
+	valueColor := getColor(noColor, color.FgCyan)
+
+	buf := &strings.Builder{}
+	fmt.Fprintf(buf, "  execution: %s\n", valueColor.Sprint("cloud"))
+	fmt.Fprintf(buf, "     output: %s\n", valueColor.Sprint(testURL))
+	fmt.Fprintf(buf, "\n")
+
+	if gs.Flags.Quiet {
+		gs.Logger.Debug(buf.String())
+	} else {
+		printToStdout(gs, buf.String())
+	}
+}
+
 // Print execution description for both cloud and local execution.
 // TODO: Clean this up as part of #1499 or #1427
 func printExecutionDescription(


### PR DESCRIPTION
## What?

```
❯ ./k6 cloud tests run --test-id 1  #  ./k6 cloud --test-id 1 works too

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

  execution: cloud
     output: https://grafana.dev.k6.io/a/k6-app/runs/69

     test status: Finished

Run    [======================================] Finished
```

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
