### PR TITLE
Test run metrics summary

### DIFF
--- a/cmd/cloud_test_run.go
+++ b/cmd/cloud_test_run.go
@@ -1,11 +1,29 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/spf13/cobra"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
 )
+
+type cmdShowTestSummary struct {
+	client    *cloudapi.K6CloudClient
+	testRunID string
+
+	thresholds bool
+	httpUrls   bool
+	checks     bool
+}
+
+func (c *cmdShowTestSummary) shouldShowAll() bool {
+	return !c.thresholds && !c.httpUrls && !c.checks
+}
 
 func getCloudTestRunCmd(gs *state.GlobalState, client *cloudapi.K6CloudClient) *cobra.Command {
 	// k6 cloud testrun
@@ -66,7 +84,223 @@ func getCloudTestRunCmd(gs *state.GlobalState, client *cloudapi.K6CloudClient) *
 		},
 	}
 
-	testrunsSub.AddCommand(listTestRun, getTestRun, downloadTestRun, getCloudCmdRunTest(gs))
+	cmdShowTestSummary := cmdShowTestSummary{}
+	showTestSummary := &cobra.Command{
+		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Use:  "summary [test-run-id]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdShowTestSummary.testRunID = args[0]
+			return cmdShowTestSummary.showTestRunSummary(client, gs)
+		},
+	}
+	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.thresholds, "thresholds", false, "show thresholds")
+	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.httpUrls, "http-urls", false, "show http urls")
+
+	testrunsSub.AddCommand(listTestRun, getTestRun, downloadTestRun, getCloudCmdRunTest(gs), showTestSummary)
 
 	return testrunsSub
+}
+
+type metricAggregate struct {
+	// label diplayed in the ui
+	Label string
+	// query used for fetching the value
+	Query string
+	Value float64
+}
+type metricSummary struct {
+	Metric     cloudapi.Metric
+	Aggregates []*metricAggregate
+}
+
+func (c *cmdShowTestSummary) showTestRunSummary(client *cloudapi.K6CloudClient, gs *state.GlobalState) error {
+
+	metrics, err := client.GetCloudTestRunMetrics(c.testRunID)
+	if err != nil {
+		return err
+	}
+	slices.SortFunc(metrics, func(a, b cloudapi.Metric) int {
+		switch {
+		case a.Origin == b.Origin:
+			return strings.Compare(a.Name, b.Name)
+		case a.Origin == "builtin":
+			return -1
+		case b.Origin == "builtin":
+			return 1
+		default:
+			return strings.Compare(a.Origin, b.Origin)
+		}
+	})
+	results := make([]chan error, len(metrics))
+	metricSummaries := make([]metricSummary, len(metrics))
+	for i, metric := range metrics {
+		summary, err := buildSummaryForMetric(metric)
+		if err != nil {
+			return err
+		}
+
+		result := make(chan error)
+		go func() {
+			err := fetchMetricAggregateValues(c.testRunID, &summary, client)
+			result <- err
+		}()
+		metricSummaries[i] = summary
+		results[i] = result
+	}
+
+	for _, result := range results {
+		err := <-result
+		if err != nil {
+			return err
+		}
+	}
+
+	// Writing and flushing labels and values to different buffers first as they are formatted differently
+	var labelsBuf bytes.Buffer
+	labelsWriter := tabwriter.NewWriter(&labelsBuf, 0, 0, 3, '.', 0)
+	for _, summary := range metricSummaries {
+		if _, err := fmt.Fprintf(labelsWriter, "%s\t:\n", summary.Metric.Name); err != nil {
+			return err
+		}
+	}
+	if err := labelsWriter.Flush(); err != nil {
+		return err
+	}
+	labelRows := bytes.Split(labelsBuf.Bytes(), []byte("\n"))
+
+	var valuesBuf bytes.Buffer
+	valuesWriter := tabwriter.NewWriter(&valuesBuf, 0, 1, 1, ' ', 0)
+	for _, summary := range metricSummaries {
+		columns := make([]string, len(summary.Aggregates))
+		for i, agg := range summary.Aggregates {
+			columns[i] = fmt.Sprintf(agg.Label, agg.Value)
+		}
+		row := strings.Join(columns, "\t")
+		if _, err := fmt.Fprintln(valuesWriter, row); err != nil {
+			return err
+		}
+	}
+	if err := valuesWriter.Flush(); err != nil {
+		return err
+	}
+	valueRows := bytes.Split(valuesBuf.Bytes(), []byte("\n"))
+
+	for i, label := range labelRows {
+		fmt.Printf("%s %s\n", label, valueRows[i])
+	}
+
+	return nil
+}
+
+func buildSummaryForMetric(metric cloudapi.Metric) (metricSummary, error) {
+	switch metric.Type {
+	case "trend":
+		return metricSummary{
+			Metric: metric,
+			Aggregates: []*metricAggregate{
+				{
+					Label: "avg=%.2f",
+					Query: "histogram_avg",
+				},
+				{
+					Label: "min=%.2f",
+					Query: "histogram_min",
+				},
+				{
+					Label: "med=%.2f",
+					Query: "histogram_quantile(0.5)",
+				},
+				{
+					Label: "max=%.2f",
+					Query: "histogram_max",
+				},
+				{
+					Label: "p(90)=%.2f",
+					Query: "histogram_quantile(0.90)",
+				},
+				{
+					Label: "p(95)=%.2f",
+					Query: "histogram_quantile(0.95)",
+				},
+			},
+		}, nil
+	case "counter":
+		return metricSummary{
+			Metric: metric,
+			Aggregates: []*metricAggregate{
+				{
+					Label: "%.2f",
+					Query: "increase",
+				},
+				{
+					Label: "%.2f u/s",
+					Query: "rate",
+				},
+			},
+		}, nil
+	case "rate":
+		return metricSummary{
+			Metric: metric,
+			Aggregates: []*metricAggregate{
+				{
+					Label: "%.2f%%",
+					Query: "ratio",
+				},
+				{
+					Label: "✓ %.2f",
+					Query: "increase_nz",
+				},
+				{
+					Label: "✗ %.2f u/s",
+					Query: "increase_z",
+				},
+			},
+		}, nil
+	case "gauge":
+		return metricSummary{
+			Metric: metric,
+			Aggregates: []*metricAggregate{
+				{
+					Label: "%.2f",
+					Query: "avg",
+				},
+				{
+					Label: "min=%.2f",
+					Query: "min",
+				},
+				{
+					Label: "max=%.2f",
+					Query: "max",
+				},
+			},
+		}, nil
+	default:
+		return metricSummary{}, fmt.Errorf("unknown metric type: %s", metric.Type)
+	}
+}
+
+func fetchMetricAggregateValues(testRunID string, summary *metricSummary, client *cloudapi.K6CloudClient) error {
+	results := make([]chan error, len(summary.Aggregates))
+	for i := range summary.Aggregates {
+		// assing to a new variable to be enclosed by the goroutine
+		aggregate := summary.Aggregates[i]
+		result := make(chan error)
+		go func() {
+			value, err := client.GetCloudTestRunMetricsAggregate(testRunID, aggregate.Query, summary.Metric.Name)
+			if err != nil {
+				result <- err
+			} else {
+				aggregate.Value = value
+				result <- nil
+			}
+		}()
+		results[i] = result
+	}
+	for _, result := range results {
+		err := <-result
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## What?

```
❯ k6 cloud testrun summary 1954201
data_received...............: 143997629.00  73807.09 u/s
data_sent...................: 36557709.00   18737.93 u/s
group_duration..............: avg=70853.92  min=53.86 med=21759.00 max=1687868.23 p(90)=190360.60 p(95)=354200.60
http_req_blocked............: avg=5.08      min=0.00  med=1.00     max=1129.55    p(90)=1.00      p(95)=1.00
http_req_connecting.........: avg=2.75      min=0.00  med=1.00     max=1068.93    p(90)=1.00      p(95)=1.00
http_req_duration...........: avg=2120.41   min=48.38 med=203.00   max=60007.86   p(90)=1127.00   p(95)=2351.00
http_req_failed.............: 0.05%         ✓ 2827.00 ✗ 51672.00 u/s
http_req_receiving..........: avg=1.42      min=0.00  med=1.00   max=502.12   p(90)=1.00    p(95)=1.00
http_req_sending............: avg=0.41      min=0.01  med=0.41   max=0.41     p(90)=0.41    p(95)=0.41
http_req_tls_handshaking....: avg=3.36      min=0.00  med=1.00   max=548.97   p(90)=1.00    p(95)=1.00
http_req_waiting............: avg=2119.82   min=48.29 med=203.00 max=60007.79 p(90)=1127.00 p(95)=2351.00
http_reqs...................: 54499.00      28.15 u/s
iteration_duration..........: avg=271739.78 min=0.00 med=132607.00 max=1833427.27 p(90)=716389.40 p(95)=999013.40
iterations..................: 652.00        0.33 u/s
k6_http_errors..............: 1270.00       1.09 u/s
vus.........................: 796.93        min=0.00   max=200.00
vus_max.....................: 1208.62       min=200.00 max=200.00
api_returned_invalid_json...: 2721.00       1.67 u/s
test_aborted................: 45.00         0.08 u/s
time_since_running..........: avg=66.03     min=12.42  med=17.00  max=296.18 p(90)=157.47 p(95)=226.83
time_since_start............: avg=385.84    min=318.44 med=337.00 max=660.85 p(90)=485.74 p(95)=573.29
time_to_test_start..........: avg=151.30    min=32.00  med=120.00 max=859.00 p(90)=255.00 p(95)=321.00
```

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
