### PR TITLE
cloud login alias

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
+
+	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
@@ -48,6 +49,7 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		getCloudTestRunCmd(gs, client),
 		getCloudScheduleCmd(client),
 		getCloudScriptValidateCmd(gs),
+		getCloudLoginCmd(gs),
 	)
 
 	return cmd

--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.k6.io/k6/cmd/state"
+)
+
+func getCloudLoginCmd(gs *state.GlobalState) *cobra.Command {
+	// k6 cloud login
+	cmdLoginCloud := getCmdLoginCloud(gs)
+
+	exampleText := getExampleText(gs, `
+  # Show the stored token.
+  {{.}} cloud login -s
+
+  # Store a token.
+  {{.}} cloud login -t YOUR_TOKEN
+
+  # Log in with an email/password.
+  {{.}} cloud login`[1:])
+
+	loginCloudCommand := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with k6 Cloud",
+		Long: `Authenticate with k6 Cloud",
+
+This will set the default token used when just "k6 run -o cloud" is passed.`,
+		Example: exampleText,
+		Args:    cobra.NoArgs,
+		RunE:    cmdLoginCloud.RunE,
+	}
+
+	loginCloudCommand.Flags().StringP("token", "t", "", "specify `token` to use")
+	loginCloudCommand.Flags().BoolP("show", "s", false, "display saved token and exit")
+	loginCloudCommand.Flags().BoolP("reset", "r", false, "reset token")
+
+	return loginCloudCommand
+}

--- a/demo.sh
+++ b/demo.sh
@@ -59,6 +59,8 @@ export default function () {
 ./k6 cloud testrun get 1
 ./k6 cloud testrun list 1
 
+./k6 cloud login -s
+
 ./k6 cloud validate correct-script.js
 
 # this needs to fail so we don't exit the script


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
Alias of `k6 login cloud` now can be called with the simplified `k6 cloud login`

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
