### PR TITLE
schedule json output & tabled output

### DIFF
--- a/cloudapi/cloudclient.go
+++ b/cloudapi/cloudclient.go
@@ -3,9 +3,7 @@ package cloudapi
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
-	"text/tabwriter"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -378,33 +376,21 @@ func (c *K6CloudClient) PatchCloudTest(testId string, data map[string]string) (*
 	return &response.CloudTest, nil
 }
 
-func (c *K6CloudClient) ListSchedule(orgId string) error {
+func (c *K6CloudClient) ListSchedule(orgId string, jsonOutput bool) ([]Schedule, error) {
 	// TODO: can add proj-id support
 	url := fmt.Sprintf("%s/v4/schedules?organization_id=%s", c.baseURL, orgId)
 
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	schedules := ListSchedulesResponse{}
 	if err := c.Do(req, &schedules); err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: use common output functionality
-	fmt.Println("********** Schedules ***************")
-	fmt.Println()
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.AlignRight)
-
-	fmt.Fprintf(w, "schedule_id\ttest_id\tactive\tnext_run\tends_type\t\n")
-	for _, schedule := range schedules.K6Schedules {
-		fmt.Fprintf(w, "%d\t%d\t%t\t%s\t%s\t\n", schedule.Id, schedule.TestId, schedule.Active, schedule.NextRun, schedule.Ends.Type)
-	}
-	w.Flush()
-
-	return nil
+	return schedules.K6Schedules, err
 }
 
 func (c *K6CloudClient) SetSchedule(testId int64, frequency string) error {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -68,6 +68,12 @@ type CloudOutput struct {
 }
 
 func NewCloudOutput(format string, headings []string) *CloudOutput {
+	return &CloudOutput{format: format, headings: headings}
+}
+
+func NewTabbedCloudOutput(formatStrings []string, headings []string) *CloudOutput {
+	format := strings.Join(formatStrings, "\t")
+	format += "\t\n"
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.AlignRight)
 	return &CloudOutput{format: format, headings: headings, tabWriter: w}
 }

--- a/cmd/cloud_schedule.go
+++ b/cmd/cloud_schedule.go
@@ -25,7 +25,7 @@ func getCloudScheduleCmd(client *cloudapi.K6CloudClient) *cobra.Command {
 				return err
 			}
 
-			out := NewCloudOutput("%d\t%d\t%t\t%s\t%s\t\n", []string{"schedule_id", "test_id", "active", "next_run", "ends_type"})
+			out := NewTabbedCloudOutput([]string{"%d", "%d", "%t", "%s", "%s"}, []string{"schedule_id", "test_id", "active", "next_run", "ends_type"})
 			if jsonOutput {
 				defer out.Json()
 			} else {


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

1. The `--json` flag is now supported for schedule listing
```
k6 cloud schedule list --org-id=4 --json
[{"active":false,"ends_type":"never","next_run":"2023-12-04T20:01:00.000000Z","schedule_id":1,"test_id":1},{"active":true,"ends_type":"never","next_run":"","schedule_id":33,"test_id":34}]
```

2. `CloudOutput` now supports a `PrintTabled` method, used to print in a nicely formatted table!
This respects the previous system and you can still use the old methods, but this is a possible implementation to have tables with the current logic!

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
