### PR TITLE
Testrun summary and metrics

### DIFF
--- a/cloudapi/cloudclient.go
+++ b/cloudapi/cloudclient.go
@@ -374,8 +374,8 @@ func (c *K6CloudClient) ListCloudTestRuns(testID string) ([]CloudTestRun, error)
 	return testsRunList.CloudTestRun, err
 }
 
-func (c *K6CloudClient) StartCloudTest(testID int64) (*CloudTestRun, error) {
-	url := fmt.Sprintf("%s/loadtests/v2/tests/%d/start-testrun", c.baseURL, testID)
+func (c *K6CloudClient) StartCloudTest(testID string) (*CloudTestRun, error) {
+	url := fmt.Sprintf("%s/loadtests/v2/tests/%s/start-testrun", c.baseURL, testID)
 
 	req, err := c.NewRequest("POST", url, nil)
 	if err != nil {

--- a/cloudapi/cloudclient.go
+++ b/cloudapi/cloudclient.go
@@ -87,20 +87,23 @@ type Account struct {
 }
 
 type CloudTestRun struct {
-	Created          time.Time `json:"created"`
-	Duration         int64     `json:"duration"`
-	ErrorDetail      string    `json:"error_detail"`
-	ID               int64     `json:"id"`
-	LoadTime         any       `json:"load_time"`
-	Note             string    `json:"note"`
-	ProcessingStatus int       `json:"processing_status"`
-	ResultStatus     int       `json:"result_status"`
-	RunProcess       string    `json:"run_process"`
-	RunStatus        int       `json:"run_status"`
-	Started          time.Time `json:"started"`
-	TestID           int64     `json:"test_id"`
-	Vus              int       `json:"vus"`
-	Script           string    `json:"script"`
+	Created           time.Time       `json:"created"`
+	Distribution      [][]interface{} `json:"distribution"`
+	Duration          int64           `json:"duration"`
+	ErrorDetail       string          `json:"error_detail"`
+	ExecutionDuration float64         `json:"execution_duration"`
+	ID                int64           `json:"id"`
+	LoadTime          any             `json:"load_time"`
+	Note              string          `json:"note"`
+	ProcessingStatus  int             `json:"processing_status"`
+	ResultStatus      int             `json:"result_status"`
+	RunProcess        string          `json:"run_process"`
+	RunStatus         int             `json:"run_status"`
+	Started           time.Time       `json:"started"`
+	TestID            int64           `json:"test_id"`
+	Vus               int             `json:"vus"`
+	VuhCost           float64         `json:"vuh_cost"`
+	Script            string          `json:"script"`
 
 	RuntimeConfig struct {
 		TestRunDetails null.String `json:"testRunDetails"`
@@ -381,7 +384,12 @@ func (c *K6CloudClient) StartCloudTest(testID int64) (*CloudTestRun, error) {
 }
 
 func (c *K6CloudClient) GetCloudTestRun(referenceID string) (*CloudTestRun, error) {
-	url := fmt.Sprintf("%s/loadtests/v2/runs/%s?$select=id,duration,script,note", c.baseURL, referenceID)
+	url := fmt.Sprintf(
+		"%s/loadtests/v2/runs/%s?$select=id,duration,script,note,"+
+			"result_status,run_status,vuh_cost,distribution,execution_duration,k6_runtime_config",
+		c.baseURL,
+		referenceID,
+	)
 
 	req, err := c.NewRequest("GET", url, nil)
 	if err != nil {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -41,7 +41,13 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		gs.Logger.Error(err)
 		os.Exit(1)
 	}
-	cmd := &cobra.Command{Use: "cloud"}
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Interact with k6 Cloud",
+		Long: `Interact with k6 Cloud
+
+See https://grafana.com/docs/grafana-cloud/k6/ for more info.`,
+	}
 
 	cmd.AddCommand(
 		getCloudProjectCmd(client),

--- a/cmd/cloud_metrics.go
+++ b/cmd/cloud_metrics.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.k6.io/k6/cloudapi"
+)
+
+func getCloudMetricsCmd(client *cloudapi.K6CloudClient) *cobra.Command {
+	metricsSub := &cobra.Command{Use: "metrics"}
+
+	var testRunID string
+	var ofJson bool
+	listMetrics := &cobra.Command{
+		Use:   "list",
+		Short: "List metrics in the test run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			metrics, err := client.GetCloudTestRunMetrics(testRunID)
+			if err != nil {
+				return err
+			}
+			slices.SortFunc(metrics, func(a, b cloudapi.Metric) int {
+				switch {
+				case a.Origin == b.Origin:
+					return strings.Compare(a.Name, b.Name)
+				case a.Origin == "builtin":
+					return -1
+				case b.Origin == "builtin":
+					return 1
+				default:
+					return strings.Compare(a.Origin, b.Origin)
+				}
+			})
+			out := NewCloudOutput("", []string{"Name", "Type", "Origin"})
+			for _, metric := range metrics {
+				out.Add(map[string]any{
+					"Name":   metric.Name,
+					"Type":   metric.Type,
+					"Origin": metric.Origin,
+				})
+			}
+
+			if ofJson {
+				out.Json()
+			} else {
+				out.Print()
+			}
+
+			return nil
+		}}
+	listMetrics.Flags().StringVarP(&testRunID, "test-run-id", "t", "", "Load Test Run ID")
+	listMetrics.Flags().BoolVar(&ofJson, "json", false, "Output in JSON")
+	listMetrics.MarkFlagRequired("test-run-id")
+
+	var (
+		metric string
+		query  string
+		start  string
+		end    string
+	)
+	queryMetric := &cobra.Command{
+		Use:   "aggregate",
+		Short: "Query metric aggregate values",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			queryResult, err := client.GetCloudTestRunMetricsAggregate(testRunID, query, metric, start, end)
+			if err != nil {
+				return err
+			}
+
+			if ofJson {
+				bytes, err := json.Marshal(queryResult)
+				if err != nil {
+					return err
+				}
+				fmt.Print(string(bytes))
+				return nil
+			}
+
+			formatMetricLabels := func(labels map[string]string) string {
+				kvPairs := make([]string, 0, len(labels))
+				for k, v := range labels {
+					if k != "__name__" {
+						kvPairs = append(kvPairs, fmt.Sprintf("%s=\"%s\"", k, v))
+					}
+				}
+				slices.Sort(kvPairs)
+				return fmt.Sprintf("{%s}", strings.Join(kvPairs, ","))
+			}
+
+			rows := make([][]string, len(queryResult.Result))
+			for i, result := range queryResult.Result {
+				rows[i] = []string{formatMetricLabels(result.Metric), fmt.Sprint(result.Values[0][1])}
+			}
+			slices.SortFunc(rows, func(a, b []string) int {
+				return strings.Compare(a[0], b[0])
+			})
+
+			out := NewCloudOutput("", []string{"labels", "value"})
+			for _, row := range rows {
+				out.Add(map[string]any{
+					"labels": row[0],
+					"value":  row[1],
+				})
+			}
+
+			out.Print()
+
+			return nil
+		}}
+	queryMetric.Flags().StringVarP(&testRunID, "test-run-id", "t", "", "Load Test Run ID")
+	queryMetric.Flags().StringVarP(&metric, "metric", "m", "",
+		"Required: name of the metric to query, with optional labels selector. Example: `http_reqs{expected_response=“true”}")
+	queryMetric.Flags().StringVar(&query, "query", "", "Required: query expression for selecting metrics")
+	queryMetric.Flags().StringVarP(&start, "start", "s", "",
+		"The start timestamp for the query range. Default is test run start. Example: '2022-01-02T10:03:00Z'")
+	queryMetric.Flags().StringVarP(&end, "end", "e", "",
+		"The end timestamp for the query range. Default is test run end. Example: '2022-01-02T10:13:00Z'")
+	queryMetric.Flags().BoolVar(&ofJson, "json", false, "Output in JSON")
+	queryMetric.MarkFlagRequired("test-run-id")
+	queryMetric.MarkFlagRequired("metric")
+	queryMetric.MarkFlagRequired("query")
+
+	metricsSub.AddCommand(listMetrics, queryMetric)
+
+	return metricsSub
+
+}

--- a/cmd/cloud_metrics.go
+++ b/cmd/cloud_metrics.go
@@ -11,7 +11,10 @@ import (
 )
 
 func getCloudMetricsCmd(client *cloudapi.K6CloudClient) *cobra.Command {
-	metricsSub := &cobra.Command{Use: "metrics"}
+	metricsSub := &cobra.Command{
+		Use:   "metrics",
+		Short: "Query test run metrics",
+	}
 
 	var testRunID string
 	var ofJson bool

--- a/cmd/cloud_script_validate.go
+++ b/cmd/cloud_script_validate.go
@@ -13,7 +13,7 @@ func getCloudScriptValidateCmd(gs *state.GlobalState) *cobra.Command {
 
 	c := &cmdCloudRunTest{
 		gs:            gs,
-		testID:        testIDNotSet,
+		testID:        "",
 		showCloudLogs: true,
 		exitOnRunning: false,
 		uploadOnly:    false,

--- a/cmd/cloud_test_run.go
+++ b/cmd/cloud_test_run.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
@@ -93,8 +95,9 @@ func getCloudTestRunCmd(gs *state.GlobalState, client *cloudapi.K6CloudClient) *
 			return cmdShowTestSummary.showTestRunSummary(client, gs)
 		},
 	}
-	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.thresholds, "thresholds", false, "show thresholds")
-	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.httpUrls, "http-urls", false, "show http urls")
+	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.thresholds, "thresholds", true, "show thresholds")
+	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.checks, "checks", true, "show thresholds")
+	showTestSummary.Flags().BoolVar(&cmdShowTestSummary.httpUrls, "http-urls", true, "show http urls")
 
 	testrunsSub.AddCommand(listTestRun, getTestRun, downloadTestRun, getCloudCmdRunTest(gs), showTestSummary)
 
@@ -102,8 +105,12 @@ func getCloudTestRunCmd(gs *state.GlobalState, client *cloudapi.K6CloudClient) *
 }
 
 type metricAggregate struct {
-	// label diplayed in the ui
-	Label string
+	// ui settings
+	Label       string
+	ValueFormat string
+	// whether to use background color
+	Background bool
+
 	// query used for fetching the value
 	Query string
 	Value float64
@@ -115,80 +122,188 @@ type metricSummary struct {
 
 func (c *cmdShowTestSummary) showTestRunSummary(client *cloudapi.K6CloudClient, gs *state.GlobalState) error {
 
-	metrics, err := client.GetCloudTestRunMetrics(c.testRunID)
-	if err != nil {
-		return err
-	}
-	slices.SortFunc(metrics, func(a, b cloudapi.Metric) int {
-		switch {
-		case a.Origin == b.Origin:
-			return strings.Compare(a.Name, b.Name)
-		case a.Origin == "builtin":
-			return -1
-		case b.Origin == "builtin":
-			return 1
-		default:
-			return strings.Compare(a.Origin, b.Origin)
-		}
-	})
-	results := make([]chan error, len(metrics))
-	metricSummaries := make([]metricSummary, len(metrics))
-	for i, metric := range metrics {
-		summary, err := buildSummaryForMetric(metric)
-		if err != nil {
+	var (
+		testRunSummary  *cloudapi.TestRunSummary
+		metricSummaries []metricSummary
+		thresholds      []cloudapi.Threshold
+		checks          []cloudapi.Check
+		httpUrls        []cloudapi.HTTPUrl
+	)
+
+	tasks := []chan error{
+		runAsync(func() error {
+			value, err := client.GetCloudTestRunSummary(c.testRunID)
+			testRunSummary = value
 			return err
-		}
-
-		result := make(chan error)
-		go func() {
-			err := fetchMetricAggregateValues(c.testRunID, &summary, client)
-			result <- err
-		}()
-		metricSummaries[i] = summary
-		results[i] = result
+		}),
+		runAsync(func() error {
+			value, err := fetchMetricSummaries(c.testRunID, client)
+			metricSummaries = value
+			return err
+		}),
+		runAsync(func() error {
+			value, err := client.GetCloudTestRunThresholds(c.testRunID)
+			thresholds = value
+			return err
+		}),
+		runAsync(func() error {
+			value, err := client.GetCloudTestRunChecks(c.testRunID)
+			checks = value
+			return err
+		}),
+		runAsync(func() error {
+			value, err := client.GetCloudTestRunHttpUrls(c.testRunID)
+			httpUrls = value
+			return err
+		}),
 	}
 
-	for _, result := range results {
+	for _, result := range tasks {
 		err := <-result
 		if err != nil {
 			return err
 		}
 	}
 
-	// Writing and flushing labels and values to different buffers first as they are formatted differently
-	var labelsBuf bytes.Buffer
-	labelsWriter := tabwriter.NewWriter(&labelsBuf, 0, 0, 3, '.', 0)
-	for _, summary := range metricSummaries {
-		if _, err := fmt.Fprintf(labelsWriter, "%s\t:\n", summary.Metric.Name); err != nil {
+	noColor := gs.Flags.NoColor || !gs.Stdout.IsTTY
+
+	fieldCells := [][]string{
+		{"metrics", ":"},
+		{"thresholds", ":"},
+		{"checks", ":"},
+		{"http", ":"},
+	}
+
+	fieldLines := formatTableBlocks(tableBlock{
+		cells:   fieldCells,
+		padding: 2,
+		padchar: ' ',
+		flags:   tabwriter.AlignRight,
+	})
+
+	output := new(bytes.Buffer)
+	currentField := 0
+	rightFieldPadding := strings.Repeat(" ", 2)
+	leftPadding := strings.Repeat(" ", len(fieldLines[currentField])) + rightFieldPadding
+
+	// pritnt metric aggregates
+	fmt.Fprint(output, fieldLines[currentField]+rightFieldPadding)
+	showMetrics(NewLeftPaddedWriter(output, leftPadding), metricSummaries, noColor)
+	currentField += 1
+
+	if c.thresholds {
+		fmt.Fprintln(output)
+		fmt.Fprint(output, fieldLines[currentField]+rightFieldPadding)
+		if err := showThresholds(
+			NewLeftPaddedWriter(output, leftPadding),
+			testRunSummary,
+			thresholds,
+			noColor,
+		); err != nil {
 			return err
 		}
 	}
-	if err := labelsWriter.Flush(); err != nil {
-		return err
-	}
-	labelRows := bytes.Split(labelsBuf.Bytes(), []byte("\n"))
+	currentField += 1
 
-	var valuesBuf bytes.Buffer
-	valuesWriter := tabwriter.NewWriter(&valuesBuf, 0, 1, 1, ' ', 0)
-	for _, summary := range metricSummaries {
-		columns := make([]string, len(summary.Aggregates))
-		for i, agg := range summary.Aggregates {
-			columns[i] = fmt.Sprintf(agg.Label, agg.Value)
-		}
-		row := strings.Join(columns, "\t")
-		if _, err := fmt.Fprintln(valuesWriter, row); err != nil {
+	if c.checks {
+		fmt.Fprintln(output)
+		fmt.Fprint(output, fieldLines[currentField]+rightFieldPadding)
+		if err := showChecks(
+			NewLeftPaddedWriter(output, leftPadding),
+			testRunSummary,
+			checks,
+			noColor,
+		); err != nil {
 			return err
 		}
 	}
-	if err := valuesWriter.Flush(); err != nil {
-		return err
-	}
-	valueRows := bytes.Split(valuesBuf.Bytes(), []byte("\n"))
+	currentField += 1
 
-	for i, label := range labelRows {
-		fmt.Printf("%s %s\n", label, valueRows[i])
+	if c.httpUrls {
+		fmt.Fprintln(output)
+		fmt.Fprint(output, fieldLines[currentField]+rightFieldPadding)
+		if err := showHttpUrls(
+			NewLeftPaddedWriter(output, leftPadding),
+			testRunSummary,
+			httpUrls,
+			noColor,
+		); err != nil {
+			return err
+		}
 	}
 
+	fmt.Println(output.String())
+
+	return nil
+}
+
+func showMetrics(w io.Writer, metricSummaries []metricSummary, noColor bool) error {
+	slices.SortFunc(metricSummaries, func(a, b metricSummary) int {
+		switch {
+		case a.Metric.Origin == b.Metric.Origin:
+			return strings.Compare(a.Metric.Name, b.Metric.Name)
+		case a.Metric.Origin == "builtin":
+			return -1
+		case b.Metric.Origin == "builtin":
+			return 1
+		default:
+			return strings.Compare(a.Metric.Origin, b.Metric.Origin)
+		}
+	})
+
+	numColumns := 0
+	for _, m := range metricSummaries {
+		if numColumns < len(m.Aggregates) {
+			numColumns = len(m.Aggregates)
+		}
+	}
+
+	labels := make([][]string, len(metricSummaries))
+	values := make([][]string, len(metricSummaries))
+	valueColor := getColor(noColor, color.FgCyan)
+	bgColor := getColor(noColor, color.FgCyan, color.Faint)
+	for i, m := range metricSummaries {
+		valColumns := make([]string, numColumns)
+		for i, agg := range m.Aggregates {
+			valuePrint := valueColor.Sprintf
+			if agg.Background {
+				valuePrint = fmt.Sprintf
+			}
+			valColumns[i] = valuePrint(agg.ValueFormat, agg.Value)
+			if agg.Label != "" {
+				valColumns[i] = agg.Label + "=" + valColumns[i]
+			}
+			if agg.Background {
+				valColumns[i] = bgColor.Sprint(valColumns[i])
+			}
+		}
+		// fill the rest of the columns with empty values to preserve formatting
+		for i := len(m.Aggregates); i < numColumns; i++ {
+			valColumns[i] = ""
+		}
+
+		labels[i] = []string{m.Metric.Name, ": "}
+		values[i] = valColumns
+	}
+
+	lines := formatTableBlocks(tableBlock{
+		cells:   labels,
+		padding: 3,
+		padchar: '.',
+	}, tableBlock{
+		cells:   values,
+		padding: 1,
+		padchar: ' ',
+	})
+
+	// add a break between builtin and custom metrics
+	builtInMetricsEnd := slices.IndexFunc(metricSummaries, func(m metricSummary) bool { return m.Metric.Origin != "builtin" })
+	for i, line := range lines {
+		if i == builtInMetricsEnd {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, line)
+	}
 	return nil
 }
 
@@ -199,28 +314,34 @@ func buildSummaryForMetric(metric cloudapi.Metric) (metricSummary, error) {
 			Metric: metric,
 			Aggregates: []*metricAggregate{
 				{
-					Label: "avg=%.2f",
-					Query: "histogram_avg",
+					Label:       "avg",
+					ValueFormat: "%.2f",
+					Query:       "histogram_avg",
 				},
 				{
-					Label: "min=%.2f",
-					Query: "histogram_min",
+					Label:       "min",
+					ValueFormat: "%.2f",
+					Query:       "histogram_min",
 				},
 				{
-					Label: "med=%.2f",
-					Query: "histogram_quantile(0.5)",
+					Label:       "med",
+					ValueFormat: "%.2f",
+					Query:       "histogram_quantile(0.5)",
 				},
 				{
-					Label: "max=%.2f",
-					Query: "histogram_max",
+					Label:       "max",
+					ValueFormat: "%.2f",
+					Query:       "histogram_max",
 				},
 				{
-					Label: "p(90)=%.2f",
-					Query: "histogram_quantile(0.90)",
+					Label:       "p(90)",
+					ValueFormat: "%.2f",
+					Query:       "histogram_quantile(0.90)",
 				},
 				{
-					Label: "p(95)=%.2f",
-					Query: "histogram_quantile(0.95)",
+					Label:       "p(95)",
+					ValueFormat: "%.2f",
+					Query:       "histogram_quantile(0.95)",
 				},
 			},
 		}, nil
@@ -229,12 +350,13 @@ func buildSummaryForMetric(metric cloudapi.Metric) (metricSummary, error) {
 			Metric: metric,
 			Aggregates: []*metricAggregate{
 				{
-					Label: "%.2f",
-					Query: "increase",
+					ValueFormat: "%.2f",
+					Query:       "increase",
 				},
 				{
-					Label: "%.2f u/s",
-					Query: "rate",
+					ValueFormat: "%.2f u/s",
+					Query:       "rate",
+					Background:  true,
 				},
 			},
 		}, nil
@@ -243,16 +365,18 @@ func buildSummaryForMetric(metric cloudapi.Metric) (metricSummary, error) {
 			Metric: metric,
 			Aggregates: []*metricAggregate{
 				{
-					Label: "%.2f%%",
-					Query: "ratio",
+					ValueFormat: "%.2f%%",
+					Query:       "ratio",
 				},
 				{
-					Label: "✓ %.2f",
-					Query: "increase_nz",
+					ValueFormat: "✓ %.0f",
+					Query:       "increase_nz",
+					Background:  true,
 				},
 				{
-					Label: "✗ %.2f u/s",
-					Query: "increase_z",
+					ValueFormat: "✗ %.0f",
+					Query:       "increase_z",
+					Background:  true,
 				},
 			},
 		}, nil
@@ -261,22 +385,57 @@ func buildSummaryForMetric(metric cloudapi.Metric) (metricSummary, error) {
 			Metric: metric,
 			Aggregates: []*metricAggregate{
 				{
-					Label: "%.2f",
-					Query: "avg",
+					ValueFormat: "%.2f",
+					Query:       "avg",
 				},
 				{
-					Label: "min=%.2f",
-					Query: "min",
+					Label:       "min",
+					ValueFormat: "%.2f",
+					Query:       "min",
+					Background:  true,
 				},
 				{
-					Label: "max=%.2f",
-					Query: "max",
+					Label:       "max",
+					ValueFormat: "%.2f",
+					Query:       "max",
+					Background:  true,
 				},
 			},
 		}, nil
 	default:
 		return metricSummary{}, fmt.Errorf("unknown metric type: %s", metric.Type)
 	}
+}
+
+func fetchMetricSummaries(testRunID string, client *cloudapi.K6CloudClient) ([]metricSummary, error) {
+	metrics, err := client.GetCloudTestRunMetrics(testRunID)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]chan error, len(metrics))
+	metricSummaries := make([]metricSummary, len(metrics))
+	for i, metric := range metrics {
+		summary, err := buildSummaryForMetric(metric)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make(chan error)
+		go func() {
+			err := fetchMetricAggregateValues(testRunID, &summary, client)
+			result <- err
+		}()
+		metricSummaries[i] = summary
+		results[i] = result
+	}
+
+	for _, result := range results {
+		err := <-result
+		if err != nil {
+			return nil, err
+		}
+	}
+	return metricSummaries, nil
 }
 
 func fetchMetricAggregateValues(testRunID string, summary *metricSummary, client *cloudapi.K6CloudClient) error {
@@ -291,6 +450,9 @@ func fetchMetricAggregateValues(testRunID string, summary *metricSummary, client
 				result <- err
 			} else {
 				aggregate.Value = value
+				if aggregate.Query == "ratio" {
+					aggregate.Value *= 100
+				}
 				result <- nil
 			}
 		}()
@@ -303,4 +465,315 @@ func fetchMetricAggregateValues(testRunID string, summary *metricSummary, client
 		}
 	}
 	return nil
+}
+
+func showThresholds(
+	w io.Writer,
+	testRunSummary *cloudapi.TestRunSummary,
+	thresholds []cloudapi.Threshold,
+	noColor bool,
+) error {
+	valueColor := getColor(noColor, color.FgCyan)
+	summary := testRunSummary.ThresholdsSummary
+	valueColor.Fprintf(w, "%d", summary.Successes)
+	fmt.Fprint(w, "/")
+	valueColor.Fprintf(w, "%d\n", summary.Total)
+
+	if len(thresholds) == 0 {
+		return nil
+	}
+	slices.SortFunc(thresholds, func(a, b cloudapi.Threshold) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	labels := make([][]string, len(thresholds))
+	values := make([][]string, len(thresholds))
+	successColor := getColor(noColor, color.FgGreen)
+	failureColor := getColor(noColor, color.FgRed)
+	for i, threshold := range thresholds {
+		separatorIdx := strings.LastIndex(threshold.Name, ":")
+		name := threshold.Name[:separatorIdx]
+		condition := strings.Replace(threshold.Name[separatorIdx+1:], " ", "", -1)
+		status := successColor.Sprint("✓")
+		if threshold.Tainted {
+			status = failureColor.Sprint("✗")
+		}
+
+		labels[i] = []string{fmt.Sprintf("%s %s", status, name), ": "}
+		values[i] = []string{
+			condition,
+			threshold.Stat + "=" + valueColor.Sprintf("%.2f", threshold.CalculatedValue),
+		}
+	}
+
+	lines := formatTableBlocks(tableBlock{
+		cells:   labels,
+		padding: 3,
+		padchar: '.',
+	}, tableBlock{
+		cells:   values,
+		padding: 1,
+		padchar: ' ',
+	})
+
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+
+	return nil
+}
+
+func showChecks(
+	w io.Writer,
+	testRunSummary *cloudapi.TestRunSummary,
+	checks []cloudapi.Check,
+	noColor bool,
+) error {
+	valueColor := getColor(noColor, color.FgCyan)
+	bgColor := getColor(noColor, color.FgCyan, color.Faint)
+
+	summary := testRunSummary.ChecksMetricSummary
+	valueColor.Fprintf(w, "%d", summary.HitsSuccesses.Int64)
+	fmt.Fprint(w, "/")
+	valueColor.Fprintf(w, "%d\n", summary.HitsTotal.Int64)
+
+	if len(checks) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(checks, func(a, b cloudapi.Check) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	labels := make([][]string, len(checks))
+	values := make([][]string, len(checks))
+	for i, check := range checks {
+		labels[i] = []string{check.Name, ": "}
+		values[i] = []string{
+			valueColor.Sprintf("%.2f%%", check.MetricSummary.SuccessRate*100),
+			bgColor.Sprintf("✓ %d", check.MetricSummary.SuccessCount),
+			bgColor.Sprintf("✗ %d", check.MetricSummary.FailCount),
+		}
+	}
+
+	lines := formatTableBlocks(tableBlock{
+		cells:   labels,
+		padding: 0,
+		padchar: ' ',
+	}, tableBlock{
+		cells:   values,
+		padding: 1,
+		padchar: ' ',
+	})
+
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+
+	return nil
+}
+
+func showHttpUrls(
+	w io.Writer,
+	testRunSummary *cloudapi.TestRunSummary,
+	urls []cloudapi.HTTPUrl,
+	noColor bool,
+) error {
+
+	if len(urls) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(urls, func(a, b cloudapi.HTTPUrl) int {
+		res := strings.Compare(a.Scenario, b.Scenario)
+		if res != 0 {
+			return res
+		}
+		res = strings.Compare(a.Name, b.Name)
+		if res != 0 {
+			return res
+		}
+		res = strings.Compare(a.Method, b.Method)
+		if res != 0 {
+			return res
+		}
+		switch {
+		case a.Status < b.Status:
+			return -1
+		case a.Status > b.Status:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	labels := make([][]string, len(urls))
+	values := make([][]string, len(urls))
+	valueColor := getColor(noColor, color.FgCyan)
+	successColor := getColor(noColor, color.FgGreen)
+	failureColor := getColor(noColor, color.FgRed)
+	for i, url := range urls {
+		expected := failureColor.Sprint("✗")
+		if url.ExpectedResponse {
+			expected = successColor.Sprint("✓")
+		}
+		labels[i] = []string{fmt.Sprintf("%s %s ", expected, url.Method), valueColor.Sprintf("%d", url.Status), ": "}
+		values[i] = []string{
+			"count=" + valueColor.Sprintf("%d", url.HTTPMetricSummary.RequestsCount),
+			"min=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.Min),
+			"avg=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.Mean),
+			"stdev=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.Stdev),
+			"p(95)=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.P95),
+			"p(99)=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.P99),
+			"max=" + valueColor.Sprintf("%.2f", url.HTTPMetricSummary.Duration.Max),
+		}
+	}
+
+	lines := formatTableBlocks(tableBlock{
+		cells:   labels,
+		padding: 0,
+		padchar: ' ',
+	}, tableBlock{
+		cells:   values,
+		padding: 1,
+		padchar: ' ',
+	})
+
+	bgColor := getColor(noColor, color.FgCyan, color.Faint)
+	summary := testRunSummary.HTTPMetricSummary
+	summaryLine := strings.Join([]string{
+		strings.Join([]string{
+			valueColor.Sprintf("%d", summary.RequestsCount-summary.FailuresCount),
+			valueColor.Sprintf("%d", summary.RequestsCount),
+		}, "/"),
+		valueColor.Sprintf("%.2f req/s", summary.RpsMean),
+		bgColor.Sprintf("max=%.2f req/s", summary.RpsMax),
+	}, "  ")
+	fmt.Fprint(w, summaryLine)
+
+	var currentUrl string
+	var currentScenario string
+	scenarioColor := getColor(noColor, color.FgCyan)
+	scenarioWriter := w
+	urlWriter := w
+	for i := range urls {
+		if currentScenario != urls[i].Scenario {
+			currentScenario = urls[i].Scenario
+			scenarioWriter = NewLeftPaddedWriter(w, "  ")
+			fmt.Fprintln(w)
+			scenarioColor.Fprintf(w, "%s:", currentScenario)
+		}
+		if currentUrl != urls[i].Name {
+			currentUrl = urls[i].Name
+			fmt.Fprintln(scenarioWriter)
+			fmt.Fprint(scenarioWriter, currentUrl)
+			urlWriter = NewLeftPaddedWriter(scenarioWriter, "  ")
+			fmt.Fprintln(urlWriter)
+		}
+		fmt.Fprintln(urlWriter, lines[i])
+	}
+
+	return nil
+}
+
+// Concatenate horizontal table blocks applying different formatting per block
+// Return an array of resulting lines
+func formatTableBlocks(blocks ...tableBlock) []string {
+	resultCells := make([][]string, len(blocks[0].cells))
+	for i := range resultCells {
+		resultCells[i] = make([]string, len(blocks))
+	}
+	for colIdx, block := range blocks {
+		var buffer bytes.Buffer
+		w := tabwriter.NewWriter(&buffer, block.minwidth, block.tabwidth, block.padding, block.padchar, block.flags)
+		writeToTable(w, block.cells)
+		rows := strings.Split(buffer.String(), "\n")
+		for rowIdx, row := range rows {
+			resultCells[rowIdx][colIdx] = row
+		}
+	}
+
+	lines := make([]string, len(resultCells))
+	for i := range lines {
+		lines[i] = strings.Join(resultCells[i], "")
+	}
+	return lines
+}
+
+func writeToTable(writer *tabwriter.Writer, cells [][]string) {
+	for i, row := range cells {
+		fmt.Fprint(writer, strings.Join(row, "\t"))
+		if i != len(cells)-1 {
+			fmt.Fprintln(writer)
+		}
+	}
+	writer.Flush()
+}
+
+type tableBlock struct {
+	cells [][]string
+
+	minwidth int
+	tabwidth int
+	padding  int
+	padchar  byte
+	flags    uint
+}
+
+// Writer insering padding at the start of each line except the first one
+type LeftPaddedWriter struct {
+	output      io.Writer
+	padBytes    []byte
+	isOnNewLine bool
+}
+
+func NewLeftPaddedWriter(output io.Writer, padding string) *LeftPaddedWriter {
+	return &LeftPaddedWriter{
+		output:   output,
+		padBytes: []byte(padding),
+	}
+}
+
+func (w *LeftPaddedWriter) Write(p []byte) (n int, err error) {
+	var nTotal int
+	for sliceStart := 0; sliceStart < len(p); {
+		newlineIdx := bytes.Index(p[sliceStart:], []byte("\n"))
+
+		sliceEnd := newlineIdx + 1
+		if newlineIdx == -1 {
+			sliceEnd = len(p)
+		}
+
+		if len(bytes.TrimSpace(p[sliceStart:sliceEnd])) != 0 && w.isOnNewLine {
+			w.isOnNewLine = false
+			n, err := w.output.Write(w.padBytes)
+			nTotal += n
+			if err != nil {
+				return nTotal, err
+			}
+		}
+
+		n, err := w.output.Write(p[sliceStart:sliceEnd])
+		nTotal += n
+		if err != nil {
+			return nTotal, err
+		}
+
+		if newlineIdx != -1 {
+			w.isOnNewLine = true
+		}
+
+		sliceStart = sliceEnd
+	}
+
+	return nTotal, nil
+}
+
+func runAsync(task func() error) chan error {
+	result := make(chan error)
+	go func() {
+		err := task()
+		result <- err
+	}()
+	return result
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,12 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 
 	// hack to keep backwards compatibility with "k6 cloud" command to run a test from script
 	subCmd, _, err := rootCmd.Find(gs.CmdArgs[1:])
-	if err == nil && subCmd != nil && subCmd.Name() == "cloud" {
+	if err == nil &&
+		subCmd != nil &&
+		subCmd.Name() == "cloud" &&
+		!slices.Contains(gs.CmdArgs, "-h") &&
+		!slices.Contains(gs.CmdArgs, "--help") {
+
 		index := slices.Index(gs.CmdArgs, "cloud")
 		args := slices.Insert(gs.CmdArgs, index+1, "test", "run")[1:]
 		rootCmd.SetArgs(args)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,8 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 		subCmd != nil &&
 		subCmd.Name() == "cloud" &&
 		!slices.Contains(gs.CmdArgs, "-h") &&
-		!slices.Contains(gs.CmdArgs, "--help") {
+		!slices.Contains(gs.CmdArgs, "--help") &&
+		slices.Index(gs.CmdArgs, "cloud") != len(gs.CmdArgs)-1 {
 
 		index := slices.Index(gs.CmdArgs, "cloud")
 		args := slices.Insert(gs.CmdArgs, index+1, "test", "run")[1:]


### PR DESCRIPTION
## What?

- Test run summary:
  - Show basic test metadata
  - Show thresholds
  - Show checks
  - Show HTTP urls
  - Add colors
  - Add indents
- List test run thresholds with `k6 cloud testrun thresholds`
- List test run HTTP URLs  `k6 cloud testrun httpurls`
- List test run metrics with ` k6 cloud metrics list`
- Query test run metric aggregates with ` k6 cloud metrics aggregate`
- Fix `k6 cloud -h` help message
- `CloudOutput`:
  - Identical table formatting for all outputs with `tabwriter`:
    - `padding: 2`
    - all headers are converted to upper-case
    - Format argument is ignored, to be cleaned up
  - All keys in json output are lower-case, spaces are replaced with `-`

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
