### PR TITLE
--test-id support for schedule delete

### DIFF
--- a/cloudapi/cloudclient.go
+++ b/cloudapi/cloudclient.go
@@ -1,6 +1,7 @@
 package cloudapi
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -477,6 +478,27 @@ func (c *K6CloudClient) ListSchedule(orgId string, jsonOutput bool) ([]Schedule,
 	}
 
 	return schedules.K6Schedules, err
+}
+
+func (c *K6CloudClient) GetScheduleFromTestId(testId int64) (*Schedule, error) {
+	url := fmt.Sprintf("%s/v4/schedules?test_id=%d", c.baseURL, testId)
+
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	schedules := ListSchedulesResponse{}
+	if err := c.Do(req, &schedules); err != nil {
+		return nil, err
+	}
+
+	if len(schedules.K6Schedules) == 0 {
+		errorMsg := fmt.Sprintf("No schedule found for test_id %d", testId)
+		return nil, errors.New(errorMsg)
+	}
+
+	return &schedules.K6Schedules[0], nil
 }
 
 func (c *K6CloudClient) SetSchedule(testId int64, frequency string) error {


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It is now possible to use a `test id` instead of a schedule id when deleting a test.
`k6 cloud schedule delete --test-id TEST_ID`

I tried looking on how to implement it in the `update` command as well, but it's getting really chaotic with arguments, arguments position and the various flags.

I still think having `--test-id` as a bool modifier that make the `ID` argument be considered as `TEST_ID` instead of `SCHEDULE_ID` a better approach but anyways here it is the delete implemented :D 


## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
